### PR TITLE
Ensures deploy only runs after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build" : "harp compile public www & browserify main.js > www/bundle.js",
     "start" : "watchify main.js -o public/bundle.js & harp server public",
-    "deploy": "npm run build & surge --project www"
+    "deploy": "npm run build && surge --project www"
   },
   "devDependencies": {
     "harp": "0.17.0",


### PR DESCRIPTION
Adds another `&` so that `npm run build` finished before `npm run deploy` starts. Thanks to this tweet: https://twitter.com/Louis_Remi/status/633557982534594560
